### PR TITLE
Explicit non-solicitation clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ We condemn:
 * Anything that compromises people’s safety
 * Solicitation and any form of spam advertising
     * Recruiters / Hiring Managers have their own special channel #recruitment-board for members to opt in.
+    * Always disclose if you have a commercial interest as deception is not tolerated.
+    * We also condemn soliciting in direct messages or in channels where that information is not appropriate.
 
 **These things are NOT OK.**
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ We condemn:
 * Stalking, doxxing, or publishing private information
 * Threats of harm, harassment
 * Anything that compromises people’s safety
+* Deception, undisclosed self promotion, solicitation
+* Use of member information to do any of the above in any other forum
 
 **These things are NOT OK.**
 
@@ -50,6 +52,7 @@ Failing to follow the community guidelines as described in this document carries
 * Josh Peak - @josh.peak
 * Cathy Lill - @cathyl 
 * Ian Belcher - @ianbelcher
+* Jonathan Milgate - @jonathan
 
 
 *The role of the moderators is to be an unbiased mediator, they will not moderate or edit anything written in the Slack unless it is required as a result of a discussed dispute.*

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ We condemn:
 * Stalking, doxxing, or publishing private information
 * Threats of harm, harassment
 * Anything that compromises people’s safety
-* Deception, undisclosed self promotion, solicitation
-* Use of member information to do any of the above in any other forum
+* Solicitation and any form of spam advertising
+    * Recruiters / Hiring Managers have their own special channel #recruitment-board for members to opt in.
 
 **These things are NOT OK.**
 


### PR DESCRIPTION
Updated the Code of Conduct to be explicit about the tactics poor recruiters have used used to give their industry a bad name.

We want to include tech recruiters but not the practices that have given them a bad name.